### PR TITLE
Respect setgid bit on directories when using --create-as-user and add new option --leave-root-perms

### DIFF
--- a/src/bindfs.1
+++ b/src/bindfs.1
@@ -67,6 +67,13 @@ the corresponding behavior of this option.
 
 Requires mounting as root.
 
+.TP
+.B \-\-leave\-root\-perms
+Do not apply permissions specified by \fB-p\fP or \fB--perms\fP to the root
+directory.  This may be useful if you are trying to set up a number of
+directories with different group ownership enforced with the setgid bit and
+group writing enabled with bindfs, but don't want the root directory itself
+to have the group write permission set.
 
 .SH FILE CREATION POLICY
 New files and directories are created so they are owned by the mounter.


### PR DESCRIPTION
The first commit will allow files created in a directory with the setgid bit set to automatically be assigned the directory's group when --create-as-user is on.  This replicates normal behavior on Linux (and, I believe, POSIX as well).

The second commit adds a new option --leave-root-perms that specifically _doesn't_ change the root directory's permissions when -p or --perms is specified.  The use case is if you are trying to set up a number of directories with different group ownership enforced with the setgid bit and group writing enabled with bindfs, but don't want the root directory itself to have the group write permission set.

I've added documentation on --leave-root-perms to the man page in the second commit.

Signed-off-by: Jonathan Dieter jdieter@lesbg.com
