### PR TITLE
Read and write throttling

### DIFF
--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -813,8 +813,9 @@ static int bindfs_write(const char *path, const char *buf, size_t size,
        if (settings.throttle_written <= 0) {
            while(1) {
               gettimeofday(&throttle_cur_time, NULL);
-              if ((throttle_cur_time.tv_sec - settings.throttle_start_time_write.tv_sec) &&
-                 (throttle_cur_time.tv_usec >= settings.throttle_start_time_write.tv_usec)) {
+              if (((throttle_cur_time.tv_sec - settings.throttle_start_time_write.tv_sec) &&
+                 (throttle_cur_time.tv_usec >= settings.throttle_start_time_write.tv_usec)) ||
+                 (throttle_cur_time.tv_sec - settings.throttle_start_time_write.tv_sec) > 1) {
                  gettimeofday(&settings.throttle_start_time_write, NULL);
                  settings.throttle_written = settings.write_limit;
                  break;


### PR DESCRIPTION
I've been suffering that fact that If I use davfs2 and my upstream is not so high it'll eat my brains out. So I tried to use trickle but it doesn't work with FUSE because it forks. So I wrote these two small patches to solve my small problem because I'll feel that if you have binds you should have capability to throttle reading and writing.
Scheduler in this patch is _STUPID_ but it works very efficiently. I've been using this some times so it seems to be also very stable I know there is some corner cases for using approach like this but this one add more than you lose because if you don't turn it on it's just business as usual.
