### PR TITLE
Remove fuse utimens dependency for OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,8 @@ if test x"$with_core_foundation" == "xyes" ; then
 	LDFLAGS="${LDFLAGS} -framework CoreFoundation"
 fi
 
+AM_CONDITIONAL(BUILD_OS_IS_DARWIN, [test x"$build_os" = darwin])
+
 my_CPPFLAGS="-D_REENTRANT -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26"
 my_CFLAGS="$my_CFLAGS -Wall"
 my_LDFLAGS="-pthread"

--- a/src/misc.h
+++ b/src/misc.h
@@ -17,6 +17,7 @@
     along with bindfs.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+
 #ifndef INC_BINDFS_MISC_H
 #define INC_BINDFS_MISC_H
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,13 @@
 
-noinst_PROGRAMS = readdir_inode utimens_nofollow
-readdir_inode_SOURCES = readdir_inode.c
-utimens_nofollow_SOURCES = utimens_nofollow.c
+UNAME_S := $(shell uname -s)
+if BUILD_OS_IS_DARWIN
+	noinst_PROGRAMS = readdir_inode
+	readdir_inode_SOURCES = readdir_inode.c
+else
+	noinst_PROGRAMS = readdir_inode utimens_nofollow
+	readdir_inode_SOURCES = readdir_inode.c
+	utimens_nofollow_SOURCES = utimens_nofollow.c
+endif
 
 TESTS = test_bindfs.rb
 SUBDIRS = internals


### PR DESCRIPTION
Fix for issue #6

Tested on OSX Mavericks 10.9.2 and osxfuse 2.6.2/2.6.4

Will need to be tested on other platforms to ensure changes only take effect in Darwin. 
