### PR TITLE
Fix caching of group members

### DIFF
--- a/src/userinfo.c
+++ b/src/userinfo.c
@@ -181,7 +181,6 @@ static int rebuild_gid_cache()
             if (uid_ent != NULL) {
                 grow_arena(&cache_arena, sizeof(uid_t));
                 ((uid_t *)ARENA_GET(cache_arena, ent->uids_offset))[ent->uid_count++] = uid_ent->uid;
-                ++ent->uid_count;
             }
         }
     }


### PR DESCRIPTION
I have found a bug concerning the caching of group members. When adding UIDs to the cache, each entry is written to the cache once, but the UID counter is incremented _twice_, leaving blank records between the UIDs in the cache. Also, the data is thus written ahead of where it should be and entries from following groups partially overwrite entries from the groups that were processed before.

The commit in this pull request fixes the double counting.
