### PR TITLE
Minor patches for MacOSX compilation

### DIFF
--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -74,6 +74,16 @@
 #include "userinfo.h"
 #include "usermap.h"
 
+/* Apple Structs */
+
+#include <sys/param.h>
+
+#define G_PREFIX   "org"
+#define G_KAUTH_FILESEC_XATTR G_PREFIX ".apple.system.Security"
+#define A_PREFIX   "com"
+#define A_KAUTH_FILESEC_XATTR A_PREFIX ".apple.system.Security"
+#define XATTR_APPLE_PREFIX   "com.apple."
+
 /* SETTINGS */
 static struct Settings {
     const char *progname;


### PR DESCRIPTION
It wouldn't compile without these patches on OSX.

I found the `#define` clauses in [your sample file](https://github.com/osxfuse/fuse/blob/master/example/fusexmp_fh.c).

And I identified the canonical definition of `MAXPATHLEN` in OSX by simply searching on my hard drive (`sys/param.h`). But then I noticed your sample file also makes use of the same header file.

