### PR TITLE
Add functionality to transparently resolve symbolic links.

### DIFF
--- a/src/bindfs.1
+++ b/src/bindfs.1
@@ -263,6 +263,11 @@ The underlying file's ctime will still be updated normally.
 Shows the hard link count of all files as 1.
 
 .TP
+.B \-\-resolve\-symlinks, \-o resolve-symlinks
+Transparently resolves symbolic links.  Disables creation of new symbolic
+links.
+
+.TP
 .B \-\-multithreaded, \-o multithreaded
 Run bindfs in multithreaded mode. While bindfs is designed to be
 otherwise thread-safe, there is currently a race condition that may pose

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -248,6 +248,8 @@ static int is_mirrored_user(uid_t uid)
 
 static char * process_path(const char *path)
 {
+    char * res;
+
     if (path == NULL) { /* possible? */
         errno = EINVAL;
         return NULL;
@@ -259,10 +261,13 @@ static char * process_path(const char *path)
     if (*path == '\0')
         path = ".";
 
-    if (settings.resolve_symlinks)
-        return realpath(path, NULL);
-    else
-        return strdup(path);
+    if (settings.resolve_symlinks) {
+        res = realpath(path, NULL);
+        if (res)
+            return res;
+    }
+
+    return strdup(path);
 }
 
 static int getattr_common(const char *procpath, struct stat *stbuf)


### PR DESCRIPTION
There exist use cases where you would want bindfs to transparently
resolve symbolic links, such as when you are creating a chroot
environment with a bound fs.  This change adds an option,
--resolve-symlinks, that modifies the behaviour of the process_path
and bindfs_symlink functions.

The process_path function is modified to return a mutable char* that
must be freed.  When settings.resolve_symlinks is enabled the
process_path function calls realpath on the relative path to
transparently resolve the symbolic link.

A side effect of this change is that broken symbolic links will appear
in directory listings but any attempt to access the file of that name
will return the ENOENT error code.  A subsequent commit offers an
alternative behaviour of not resolving broken symbolic links.

All callers of process_path are modified to check the return value of
process_path to make sure realpath and strdup were successful.  They
also free the result after use to prevent memory leakage.

The bindfs_symlink function is modified to return EPERM when
resolve-symlinks is enabled.  This must be done to prevent access to
arbitrary files on the filesystem.