### PR TITLE
Fix issue when reading directory with many entries

### DIFF
--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -608,7 +608,7 @@ static int bindfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
         memset(&st, 0, sizeof(st));
         st.st_ino = de->d_ino;
         st.st_mode = de->d_type << 12;
-        if (filler(buf, de->d_name, &st, telldir(dp)))
+        if (filler(buf, de->d_name, &st, 0))
             break;
     }
 


### PR DESCRIPTION
By some reason reading a directory with many entries(1000+) caused an EIO(-5) error. 

Letting libfuse manage the readdir offsets fixed the issue.
