### PR TITLE
tests: fix building out of place

### DIFF
--- a/tests/internals/Makefile.am
+++ b/tests/internals/Makefile.am
@@ -1,14 +1,14 @@
 
 noinst_HEADERS = test_common.h
 noinst_PROGRAMS = test_internals test_rate_limiter
-test_internals_SOURCES = test_internals.c test_common.c $(top_builddir)/src/misc.c
-test_rate_limiter_SOURCES = test_rate_limiter.c test_common.c $(top_builddir)/src/rate_limiter.c
+test_internals_SOURCES = test_internals.c test_common.c $(top_srcdir)/src/misc.c
+test_rate_limiter_SOURCES = test_rate_limiter.c test_common.c $(top_srcdir)/src/rate_limiter.c
 
-test_internals_CPPFLAGS = ${my_CPPFLAGS} ${fuse_CFLAGS} -I. -I$(top_builddir)/src
+test_internals_CPPFLAGS = ${my_CPPFLAGS} ${fuse_CFLAGS} -I. -I$(top_srcdir)/src
 test_internals_CFLAGS = ${my_CFLAGS}
 test_internals_LDADD = ${my_LDFLAGS}
 
-test_rate_limiter_CPPFLAGS = ${my_CPPFLAGS} ${fuse_CFLAGS} -I. -I$(top_builddir)/src
+test_rate_limiter_CPPFLAGS = ${my_CPPFLAGS} ${fuse_CFLAGS} -I. -I$(top_srcdir)/src
 test_rate_limiter_CFLAGS = ${my_CFLAGS}
 test_rate_limiter_LDADD = ${my_LDFLAGS}
 

--- a/tests/internals/test_internals_valgrind.sh
+++ b/tests/internals/test_internals_valgrind.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-cd `dirname "$0"`
+if [ ! -x ./test_internals ]; then
+    cd `dirname "$0"`
+fi
 valgrind --error-exitcode=100 ./test_internals

--- a/tests/internals/test_rate_limiter_valgrind.sh
+++ b/tests/internals/test_rate_limiter_valgrind.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-cd `dirname "$0"`
+if [ ! -x ./test_rate_limiter ]; then
+    cd `dirname "$0"`
+fi
 valgrind --error-exitcode=100 ./test_rate_limiter

--- a/tests/test_bindfs.rb
+++ b/tests/test_bindfs.rb
@@ -18,7 +18,10 @@
 #   along with bindfs.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-require './common.rb'
+# if we are being run by make check it will set srcdir and we should use it
+localsrc_path = ENV['srcdir'] || '.'
+
+require localsrc_path + '/common.rb'
 
 include Errno
 
@@ -39,7 +42,7 @@ $nobody_uid = nobody_uid = Etc.getpwnam('nobody').uid
 $nobody_gid = nobody_gid = Etc.getpwnam('nobody').gid
 $nobody_group = nobody_group = Etc.getgrgid(nobody_gid).name
 
-$tests_dir = File.dirname(File.realpath(__FILE__))
+$tests_dir = File.realpath('.')
 
 
 testenv("") do


### PR DESCRIPTION
The path to the source files should be top_srcdir not top_builddir. When
building in place these are both the same so this doesn't fail but is
technically wrong. This change will allow both cases to work.

To demonstrace how this was broken before and to ensure it is fixed now
you can do the following:
./autogen.sh && mkdir -p build && cd build && ../configure && make

Running make check out of place still doesn't work but that will require
a bit more change.