### PR TITLE
Fix issue where sgid is set and gid-offset is used

### DIFF
--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -450,12 +450,17 @@ static int chown_new_file(const char *path, struct fuse_context *fc, int (*chown
     file_owner = usermap_get_uid_or_default(settings.usermap_reverse, fc->uid, file_owner);
     file_group = usermap_get_gid_or_default(settings.usermap_reverse, fc->gid, file_group);
 
-    if (!unapply_uid_offset(&file_owner)) {
-        return -UID_GID_OVERFLOW_ERRNO;
+    if (file_owner != (uid_t)-1) {
+		if (!unapply_uid_offset(&file_owner)) {
+           return -UID_GID_OVERFLOW_ERRNO;
+		}
     }
-    if (!unapply_gid_offset(&file_group)) {
-        return -UID_GID_OVERFLOW_ERRNO;
-    }
+
+    if (file_group != (gid_t)-1) {
+        if (!unapply_gid_offset(&file_group)) {
+            return -UID_GID_OVERFLOW_ERRNO;
+        }
+	}
 
     if (settings.create_for_uid != -1)
         file_owner = settings.create_for_uid;

--- a/src/usermap.c
+++ b/src/usermap.c
@@ -99,6 +99,7 @@ const char* usermap_errorstr(UsermapStatus status)
 uid_t usermap_get_uid_or_default(UserMap *map, uid_t u, uid_t deflt)
 {
     int i;
+	if (u == -1) return -1;
     for (i = 0; i < map->user_size; ++i) {
         if (map->user_from[i] == u) {
             return map->user_to[i];
@@ -110,6 +111,7 @@ uid_t usermap_get_uid_or_default(UserMap *map, uid_t u, uid_t deflt)
 gid_t usermap_get_gid_or_default(UserMap *map, gid_t g, gid_t deflt)
 {
     int i;
+	if (g == -1) return -1;
     for (i = 0; i < map->group_size; ++i) {
         if (map->group_from[i] == g) {
             return map->group_to[i];


### PR DESCRIPTION
I found an issue where using bindfs with gid shifting or mapping together with SGID bit causes bindfs to set (-1) value to the GID. 
This in turn breaks the gid inside a forward shifted bind mount.