### PR TITLE
build: fix build failure with -fno-common

### DIFF
--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -26,7 +26,7 @@
 /* When we are idle, we allow some time to be "credited" to the next writer.
  * Otherwise, the short pause between requests would "go to waste", lowering
  * the throughput when there is only one requester. */
-const double rate_limiter_idle_credit;
+extern const double rate_limiter_idle_credit;
 
 typedef struct RateLimiter {
     double rate;  /* bytes / second */


### PR DESCRIPTION
$ ./configure CFLAGS=-fno-common && make
ld: rate_limiter.o:(.rodata+0x0): multiple definition of
"rate_limiter_idle_credit"; bindfs.o:(.rodata+0x0): first defined here

References: https://bugzilla.opensuse.org/1160244