### PR TITLE
New parameters --map-passwd and --map-group

### DIFF
--- a/src/bindfs.1
+++ b/src/bindfs.1
@@ -68,6 +68,22 @@ the corresponding behavior of this option.
 Requires mounting as root.
 
 .TP
+.B \-\-map-passwd=\fI<passwdfile>\fP, \-o map-passwd=...
+.PD 0
+.TP
+.B \-\-map-group=\fI<groupfile>\fP, \-o map-group=...
+Like \fB--map=...\fP, but reads the UID/GID mapping from passwd and group
+files (like \fI/etc/passwd\fP and \fI/etc/group\fP). Helpful to restore
+system backups where UIDs/GIDs differ.
+
+Example usage:
+
+bindfs --map-passwd=/mnt/orig/etc/passwd \\ --map-passwd=/mnt/orig/etc/group 
+    /mnt/orig /mnt/mapped\fP
+
+Requires mounting as root.
+
+.TP
 .B \-\-uid\-offset=..., \-o uid\-offset=...
 Works like \-\-map, but adds the given number to all file owner user IDs.
 For instance, \fB--uid-offset=100000\fP causes a file owned by user \fI123\fP

--- a/src/bindfs.1
+++ b/src/bindfs.1
@@ -66,20 +66,22 @@ Currently, the options \fB--force-user\fP, \fB--force-group\fP, \fB--mirror\fP,
 the corresponding behavior of this option.
 
 Requires mounting as root.
-
 .TP
-.B \-\-map-passwd=\fI<passwdfile>\fP, \-o map-passwd=...
+.B \-\-map-passwd=\fI<passwdfile>\fP, \-o map-passwd=\fI<passwdfile>\fP
 .PD 0
 .TP
-.B \-\-map-group=\fI<groupfile>\fP, \-o map-group=...
+.B \-\-map-group=\fI<groupfile>\fP, \-o map-group=\fI<groupfile>\fP
 Like \fB--map=...\fP, but reads the UID/GID mapping from passwd and group
 files (like \fI/etc/passwd\fP and \fI/etc/group\fP). Helpful to restore
 system backups where UIDs/GIDs differ.
 
 Example usage:
 
-bindfs --map-passwd=/mnt/orig/etc/passwd \\ --map-passwd=/mnt/orig/etc/group 
-    /mnt/orig /mnt/mapped\fP
+\&    bindfs --map-passwd=/mnt/orig/etc/passwd \\
+.br
+\&        \--map-passwd=/mnt/orig/etc/group \\
+.br  
+\&        /mnt/orig /mnt/mapped
 
 Requires mounting as root.
 

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -1546,7 +1546,7 @@ static void print_usage(const char *progname)
            "  -M      --mirror-only=... Like --mirror but disallow access for\n"
            "                            all other users.\n"
            " --map=user1/user2:...      Let user2 see files of user1 as his own.\n"
-           " --map-passwd=<passwdfile   Load uid mapping from <passwdfile>.\n"
+           " --map-passwd=<passwdfile>  Load uid mapping from <passwdfile>.\n"
            " --map-group=<groupfile>    Load gid mapping from <groupfile>.\n"
            " --uid-offset=...           Set file uid = uid + offset.\n"
            " --gid-offset=...           Set file gid = gid + offset.\n"

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -1922,7 +1922,6 @@ static int parse_map_file(UserMap *map, UserMap *reverse_map, char *file, int as
             fprintf(stderr, "%s\n", usermap_errorstr(status));
             goto exit;
         }
-        printf("%d -> %d\n", uid_from, uid_to);
         status = usermap_add(reverse_map, uid_to, uid_from);
         if (status != 0) {
             fprintf(stderr, "%s\n", usermap_errorstr(status));


### PR DESCRIPTION
New parameters --map-passwd and --map-group.

These will read the UID and GID mapping from passwd / group files
like /etc/passwd and /etc/group. This can be used when restoring
backups where IDs differ.

Example:

`sudo bindfs --map-passwd=/mnt/original/etc/passwd --map-group=/mnt/original/etc/group /mnt/original /mnt/mapped`