### PR TITLE
Add test for Unix socket ancillary data

### DIFF
--- a/tests/test_bindfs.rb
+++ b/tests/test_bindfs.rb
@@ -939,6 +939,18 @@ testenv("", :title => "socket files") do
   end
 end
 
+testenv("", :title => "socket files ancillary data") do
+  UNIXServer.open("src/sock") do |server|
+    UNIXSocket.open("mnt/sock") do |client|
+      socket = server.accept
+      socket.send_io STDIN
+      socket.close
+      io = client.recv_io
+      assert { File.identical?(STDIN, io) }
+    end
+  end
+end
+
 # FIXME: this stuff around testenv is a hax, and testenv may also exit(), which defeats the 'ensure' below.
 # the test setup ought to be refactored. It might well use MiniTest or something.
 # TODO: support FreeBSD in this test (different group management commands)


### PR DESCRIPTION
This PR adds test that checks whether socket ancillary data can be properly transmitted through binds-mounted UNIX domain socket.

----

And in fact it _does work_ on macOS + macFUSE. What makes me sad because I was trying to figure out why _apps running inside chroot on top of  bindfs-mounted directory that contains a hardlink to mDNSResponder UNIX socket file_ (sic!) cannot resolve hostnames. The very similar issue is [described on stackoverflow](https://stackoverflow.com/q/33356677/5866817), however it isn't clear what is their solution.

Anyway, this test shows that bindfs + macFUSE _seem_ to support this setup properly and I thought it is valuable enough to be added to bindfs testsuite.