### PR TITLE
Allow mount to use bindfs with configuration via /etc/fstab.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ if test x"$with_core_foundation" == "xyes" ; then
     LDFLAGS="${LDFLAGS} -framework CoreFoundation"
 fi
 
-AM_CONDITIONAL(BUILD_OS_IS_DARWIN, [test x"$build_os" = darwin])
+AM_CONDITIONAL([BUILD_OS_IS_DARWIN], [case $build_os in darwin* ) true ;; * ) false ;; esac])
 
 # _XOPEN_SOURCE is >= 500 for pread/pwrite; >= 700 for utimensat.
 # __BSD_VISIBLE is for flock() on FreeBSD. It otherwise gets hidden by _XOPEN_SOURCE.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,3 +10,14 @@ AM_CFLAGS = ${my_CFLAGS}
 bindfs_LDADD = ${fuse_LIBS} ${fuse3_LIBS} ${fuse_t_LIBS} ${my_LDFLAGS}
 
 man_MANS = bindfs.1
+
+if BUILD_OS_IS_DARWIN
+bindfs_BUNDLEDIR = /Library/Filesystems/bindfs.fs
+bindfs_BUNDLEBINDIR = "${bindfs_BUNDLEDIR}/Contents/Resources"
+
+install-exec-hook:
+	(mkdir -p "${bindfs_BUNDLEBINDIR}"; ln -s "${bindir}/bindfs" "${bindfs_BUNDLEBINDIR}/mount_bindfs")
+
+uninstall-hook:
+	(rm -rf ${bindfs_BUNDLEDIR})
+endif


### PR DESCRIPTION
Apple's implementation of `mount` looks for `/Library/Filesystems/<type>.fs/Contents/Resources/mount_<type>`, which is user writable, where `<type>` is supplied via the `-t` argument or is the third argument in /etc/fstab.
