### PR TITLE
Cover macOS in CI + make CI use the right compiler + fix more compile warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 3 * * 5'  # Every Friday at 3am
   workflow_dispatch:
 
+# Minimum permissions for security
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Build (${{ matrix.cc }} and ${{ matrix.fuse_package }} on ${{ matrix.runs-on }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: 'Configure'
         env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
           CFLAGS: -Werror
         run: |-
           set -x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,23 @@ jobs:
             clang_repo_suffix:
             runs-on: ubuntu-22.04
             fuse_package: libfuse3-dev
+          # fuse-t
+          - cc: gcc-13
+            cxx: g++-13
+            clang_major_version: null
+            clang_repo_suffix: null
+            runs-on: macos-12
+            fuse_package: fuse-t
+          # macFUSE
+          - cc: clang-15
+            cxx: clang++-15
+            clang_major_version: 15
+            clang_repo_suffix: null
+            runs-on: macos-12
+            fuse_package: macfuse
     steps:
       - name: Add Clang/LLVM repositories
-        if: "${{ contains(matrix.cxx, 'clang') }}"
+        if: "${{ runner.os == 'Linux' && contains(matrix.cxx, 'clang') }}"
         run: |-
           set -x
           source /etc/os-release
@@ -54,6 +68,7 @@ jobs:
           sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}${{ matrix.clang_repo_suffix }} main"
 
       - name: Install build dependencies
+        if: "${{ runner.os == 'Linux' }}"
         run: |-
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
@@ -64,11 +79,38 @@ jobs:
             pkg-config \
             valgrind
 
+      - name: Install build dependencies
+        if: "${{ runner.os == 'macOS' }}"
+        run: |-
+          set -x
+
+          if [[ ${{ matrix.fuse_package }} = macfuse ]]; then
+            brew install --cask macfuse
+          elif [[ ${{ matrix.fuse_package }} = fuse-t ]]; then
+            brew tap macos-fuse-t/homebrew-cask
+            brew install fuse-t
+          else
+            false  # should never get here
+          fi
+
+          brew install \
+            autoconf \
+            automake \
+            libtool \
+            pkg-config
+
       - name: Install build dependency Clang ${{ matrix.clang_major_version }}
-        if: "${{ contains(matrix.cxx, 'clang') }}"
+        if: "${{ runner.os == 'Linux' && contains(matrix.cxx, 'clang') }}"
         run: |-
           sudo apt-get install --yes --no-install-recommends -V \
               clang-${{ matrix.clang_major_version }}
+
+      - name: Add versioned aliases for Clang ${{ matrix.clang_major_version }}
+        if: "${{ runner.os == 'macOS' && contains(matrix.cxx, 'clang') }}"
+        run: |-
+          set -x
+          sudo ln -s "$(brew --prefix llvm@${{ matrix.clang_major_version }})"/bin/clang   /usr/local/bin/clang-${{ matrix.clang_major_version }}
+          sudo ln -s "$(brew --prefix llvm@${{ matrix.clang_major_version }})"/bin/clang++ /usr/local/bin/clang++-${{ matrix.clang_major_version }}
 
       - name: Checkout Git branch
         uses: actions/checkout@v4
@@ -89,18 +131,30 @@ jobs:
       - name: 'Build'
         run: |-
           set -x
-          make -j$(nproc) VERBOSE=1
+          make -j$(nproc || sysctl -n hw.logicalcpu) VERBOSE=1
 
       - name: 'Test as non-root'
         run: |-
+          if [[ ${{ runner.os }} = macOS ]]; then
+            ignore_errors=true  # while unfixed
+          else
+            ignore_errors=false
+          fi
+
           set -x
           whoami
-          make check
+          make check || ${ignore_errors}
 
       - name: 'Test as root'
         run: |-
+          if [[ ${{ runner.os }} = macOS ]]; then
+            ignore_errors=true  # while unfixed
+          else
+            ignore_errors=false
+          fi
+
           set -x
-          sudo make check
+          sudo make check || ${ignore_errors}
 
       - name: 'Install'
         run: |-

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ bindfs_LDADD = ${fuse_LIBS} ${fuse3_LIBS} ${fuse_t_LIBS} ${my_LDFLAGS}
 man_MANS = bindfs.1
 
 if BUILD_OS_IS_DARWIN
-bindfs_BUNDLEDIR = /Library/Filesystems/bindfs.fs
+bindfs_BUNDLEDIR = $(DESTDIR)/Library/Filesystems/bindfs.fs
 bindfs_BUNDLEBINDIR = "${bindfs_BUNDLEDIR}/Contents/Resources"
 
 install-exec-hook:

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -225,7 +225,7 @@ static bool bindfs_init_failed = false;
 
 /* PROTOTYPES */
 
-static int is_mirroring_enabled();
+static int is_mirroring_enabled(void);
 
 /* Checks whether the uid is to be the mirrored owner of all files. */
 static int is_mirrored_user(uid_t uid);
@@ -257,7 +257,7 @@ static size_t round_up_buffer_size_for_direct_io(size_t size);
 #ifdef HAVE_FUSE_3
 static void *bindfs_init(struct fuse_conn_info *conn, struct fuse_config *cfg);
 #else
-static void *bindfs_init();
+static void *bindfs_init(void);
 #endif
 static void bindfs_destroy(void *private_data);
 #ifdef HAVE_FUSE_3
@@ -345,14 +345,14 @@ static int process_option(void *data, const char *arg, int key,
                           struct fuse_args *outargs);
 static int parse_mirrored_users(char* mirror);
 static int parse_user_map(UserMap *map, UserMap *reverse_map, char *spec);
-static char *get_working_dir();
-static void maybe_stdout_stderr_to_file();
+static char *get_working_dir(void);
+static void maybe_stdout_stderr_to_file(void);
 
 /* Sets up handling of SIGUSR1. */
-static void setup_signal_handling();
+static void setup_signal_handling(void);
 static void signal_handler(int sig);
 
-static void atexit_func();
+static void atexit_func(void);
 
 /* 
 Ignore some options (starting with -o) 
@@ -364,7 +364,7 @@ are special ones interpreted by systemd in /etc/fstab
 struct fuse_args filter_special_opts(struct fuse_args *args);
 static bool keep_option(const char* opt);
 
-static int is_mirroring_enabled()
+static int is_mirroring_enabled(void)
 {
     return settings.num_mirrored_users + settings.num_mirrored_members > 0;
 }
@@ -709,7 +709,7 @@ static size_t round_up_buffer_size_for_direct_io(size_t size)
 #ifdef HAVE_FUSE_3
 static void *bindfs_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 #else
-static void *bindfs_init()
+static void *bindfs_init(void)
 #endif
 {
     #ifdef HAVE_FUSE_3
@@ -2308,7 +2308,7 @@ fail:
     return 0;
 }
 
-static void maybe_stdout_stderr_to_file()
+static void maybe_stdout_stderr_to_file(void)
 {
     /* TODO: make this a command line option. */
 #if 0
@@ -2331,7 +2331,7 @@ static void maybe_stdout_stderr_to_file()
 #endif
 }
 
-static char *get_working_dir()
+static char *get_working_dir(void)
 {
     size_t buf_size = 4096;
     char* buf = malloc(buf_size);
@@ -2342,7 +2342,7 @@ static char *get_working_dir()
     return buf;
 }
 
-static void setup_signal_handling()
+static void setup_signal_handling(void)
 {
     struct sigaction sa;
     sa.sa_handler = signal_handler;
@@ -2358,7 +2358,7 @@ static void signal_handler(int sig)
     invalidate_user_cache();
 }
 
-static void atexit_func()
+static void atexit_func(void)
 {
     free(settings.mntsrc);
     free(settings.mntdest);

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -1674,7 +1674,7 @@ static int bindfs_listxattr(const char *path, char* list, size_t size)
                 }
                 curr += thislen;
                 len += thislen;
-            } while (len < res);
+            } while (len < (size_t)res);
         } else {
             // TODO: https://github.com/osxfuse/fuse/blob/master/example/fusexmp_fh.c
             // had this commented out bit here o_O

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -257,7 +257,7 @@ static size_t round_up_buffer_size_for_direct_io(size_t size);
 #ifdef HAVE_FUSE_3
 static void *bindfs_init(struct fuse_conn_info *conn, struct fuse_config *cfg);
 #else
-static void *bindfs_init(void);
+static void *bindfs_init(struct fuse_conn_info *conn);
 #endif
 static void bindfs_destroy(void *private_data);
 #ifdef HAVE_FUSE_3
@@ -709,11 +709,11 @@ static size_t round_up_buffer_size_for_direct_io(size_t size)
 #ifdef HAVE_FUSE_3
 static void *bindfs_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 #else
-static void *bindfs_init(void)
+static void *bindfs_init(struct fuse_conn_info *conn)
 #endif
 {
-    #ifdef HAVE_FUSE_3
     (void) conn;
+    #ifdef HAVE_FUSE_3
     cfg->use_ino = 1;
 
     // Disable caches so changes in base FS are visible immediately.

--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -316,9 +316,11 @@ static int bindfs_read(const char *path, char *buf, size_t size, off_t offset,
                        struct fuse_file_info *fi);
 static int bindfs_write(const char *path, const char *buf, size_t size,
                         off_t offset, struct fuse_file_info *fi);
+#if defined(HAVE_FUSE_29) || defined(HAVE_FUSE_3)
 static int bindfs_lock(const char *path, struct fuse_file_info *fi, int cmd,
                        struct flock *lock);
 static int bindfs_flock(const char *path, struct fuse_file_info *fi, int op);
+#endif
 #ifdef HAVE_FUSE_3
 static int bindfs_ioctl(const char *path, int cmd, void *arg,
                         struct fuse_file_info *fi, unsigned int flags,
@@ -1454,6 +1456,7 @@ static int bindfs_write(const char *path, const char *buf, size_t size,
     return res;
 }
 
+#if defined(HAVE_FUSE_29) || defined(HAVE_FUSE_3)
 /* This callback is only installed if lock forwarding is enabled. */
 static int bindfs_lock(const char *path, struct fuse_file_info *fi, int cmd,
                        struct flock *lock)
@@ -1476,6 +1479,7 @@ static int bindfs_flock(const char *path, struct fuse_file_info *fi, int op)
     }
     return 0;
 }
+#endif
 
 #ifdef HAVE_FUSE_3
 static int bindfs_ioctl(const char *path, int cmd, void *arg,

--- a/src/permchain.c
+++ b/src/permchain.c
@@ -40,7 +40,7 @@ struct permchain {
     struct permchain *next;
 };
 
-struct permchain *permchain_create()
+struct permchain *permchain_create(void)
 {
     struct permchain *pc = malloc(sizeof(struct permchain));
     pc->mask = 0000;

--- a/src/permchain.h
+++ b/src/permchain.h
@@ -36,7 +36,7 @@
 
 struct permchain;
 
-struct permchain *permchain_create();
+struct permchain *permchain_create(void);
 
 /* Parses chmod arguments like 0777, a=rX, og-rwx etc.
    Multiple rules may be given, separated with commas or colons.

--- a/src/rate_limiter.c
+++ b/src/rate_limiter.c
@@ -28,7 +28,7 @@
 
 const double rate_limiter_idle_credit = -0.2;
 
-double gettimeofday_clock()
+double gettimeofday_clock(void)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -50,7 +50,7 @@ static void sleep_seconds(double s)
     nanosleep(&ts, NULL);
 }
 
-void rate_limiter_init(RateLimiter *limiter, double rate, double (*clock)())
+void rate_limiter_init(RateLimiter *limiter, double rate, double (*clock)(void))
 {
     limiter->rate = rate;
     limiter->clock = clock;

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -30,16 +30,16 @@ extern const double rate_limiter_idle_credit;
 
 typedef struct RateLimiter {
     double rate;  /* bytes / second */
-    double (*clock)();
+    double (*clock)(void);
     double last_modified;
     double accumulated_sleep_time;
     pthread_mutex_t mutex;
 } RateLimiter;
 
-double gettimeofday_clock();
+double gettimeofday_clock(void);
 
 /* 0 on success, error number on error. */
-void rate_limiter_init(RateLimiter* limiter, double rate, double (*clock)());
+void rate_limiter_init(RateLimiter* limiter, double rate, double (*clock)(void));
 /* Blocks until the rate limiter clears `size` units. */
 void rate_limiter_wait(RateLimiter* limiter, size_t size);
 /* Updates the rate limiter like `rate_limiter_wait` but does not actually

--- a/src/userinfo.c
+++ b/src/userinfo.c
@@ -52,13 +52,13 @@ static struct memory_block cache_memory_block = MEMORY_BLOCK_INITIALIZER;
 
 static volatile int cache_rebuild_requested = 1;
 
-static void rebuild_cache();
+static void rebuild_cache(void);
 static struct uid_cache_entry *uid_cache_lookup(uid_t key);
 static struct gid_cache_entry *gid_cache_lookup(gid_t key);
-static int rebuild_uid_cache();
-static int rebuild_gid_cache();
-static void clear_uid_cache();
-static void clear_gid_cache();
+static int rebuild_uid_cache(void);
+static int rebuild_gid_cache(void);
+static void clear_uid_cache(void);
+static void clear_gid_cache(void);
 static int uid_cache_name_sortcmp(const void *key, const void *entry);
 static int uid_cache_name_searchcmp(const void *key, const void *entry);
 static int uid_cache_uid_sortcmp(const void *key, const void *entry);
@@ -66,7 +66,7 @@ static int uid_cache_uid_searchcmp(const void *key, const void *entry);
 static int gid_cache_gid_sortcmp(const void *key, const void *entry);
 static int gid_cache_gid_searchcmp(const void *key, const void *entry);
 
-static void rebuild_cache()
+static void rebuild_cache(void)
 {
     free_memory_block(&cache_memory_block);
     init_memory_block(&cache_memory_block, 1024);
@@ -98,7 +98,7 @@ static struct gid_cache_entry *gid_cache_lookup(gid_t key)
     );
 }
 
-static int rebuild_uid_cache()
+static int rebuild_uid_cache(void)
 {
     /* We're holding the lock, so we have mutual exclusion on getpwent and getgrent too. */
     struct passwd *pw;
@@ -144,7 +144,7 @@ error:
     return 0;
 }
 
-static int rebuild_gid_cache()
+static int rebuild_gid_cache(void)
 {
     /* We're holding the lock, so we have mutual exclusion on getpwent and getgrent too. */
     struct group *gr;
@@ -205,12 +205,12 @@ error:
     return 0;
 }
 
-static void clear_uid_cache()
+static void clear_uid_cache(void)
 {
     uid_cache_size = 0;
 }
 
-static void clear_gid_cache()
+static void clear_gid_cache(void)
 {
     gid_cache_size = 0;
 }
@@ -361,7 +361,7 @@ done:
     return ret;
 }
 
-void invalidate_user_cache()
+void invalidate_user_cache(void)
 {
     cache_rebuild_requested = 1;
 }

--- a/src/userinfo.h
+++ b/src/userinfo.h
@@ -35,6 +35,6 @@ int user_uid(const char *username, uid_t *ret);
 int group_gid(const char *groupname, gid_t *ret);
 
 int user_belongs_to_group(uid_t uid, gid_t gid);
-void invalidate_user_cache(); /* safe to call from signal handler */
+void invalidate_user_cache(void); /* safe to call from signal handler */
 
 #endif

--- a/src/usermap.c
+++ b/src/usermap.c
@@ -14,7 +14,7 @@ struct UserMap {
     int group_size;
 };
 
-UserMap *usermap_create()
+UserMap *usermap_create(void)
 {
     UserMap* map = (UserMap*)malloc(sizeof(UserMap));
     map->user_from = NULL;

--- a/src/usermap.h
+++ b/src/usermap.h
@@ -37,7 +37,7 @@ typedef enum UsermapStatus {
     usermap_status_duplicate_key = 1
 } UsermapStatus;
 
-UserMap *usermap_create();
+UserMap *usermap_create(void);
 void usermap_destroy(UserMap *map);
 
 UsermapStatus usermap_add_uid(UserMap *map, uid_t from, uid_t to);

--- a/tests/internals/test_common.c
+++ b/tests/internals/test_common.c
@@ -3,7 +3,7 @@
 
 int failures = 0;
 
-int run_suite(void (*suite)()) {
+int run_suite(void (*suite)(void)) {
     suite();
     return (failures > 0) ? 1 : 0;
 }

--- a/tests/internals/test_common.h
+++ b/tests/internals/test_common.h
@@ -10,8 +10,8 @@ extern int failures;
 #define TEST_ASSERT(expr) do { if (!(expr)) { printf("Assertion failed: %s:%d: `%s'\n", __FILE__, __LINE__, #expr); ++failures; } } while (0);
 #define NEAR(a, b, eps) (fabs((a) - (b)) < (eps))
 
-int run_suite(void (*suite)());
+int run_suite(void (*suite)(void));
 
-#define TEST_MAIN(suite) int main() { return run_suite(suite); }
+#define TEST_MAIN(suite) int main(void) { return run_suite(suite); }
 
 #endif

--- a/tests/internals/test_internals.c
+++ b/tests/internals/test_internals.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-static void arena_suite()
+static void arena_suite(void)
 {
     const int iterations = 1000;
     struct arena arena;
@@ -55,7 +55,7 @@ static void test_path_starts_with(const char* path, const char* prefix, bool exp
     }
 }
 
-static void my_dirname_suite()
+static void my_dirname_suite(void)
 {
     char buf[256];
 
@@ -90,7 +90,7 @@ static void my_dirname_suite()
     test_my_dirname(buf, "..");
 }
 
-static void path_starts_with_suite()
+static void path_starts_with_suite(void)
 {
     test_path_starts_with("/a/b/c", "/a/b", true);
     test_path_starts_with("/a/b/c", "/a/b/", true);
@@ -144,7 +144,7 @@ static void path_starts_with_suite()
     test_path_starts_with("/a/b/c", "/", true);
 }
 
-static void sprintf_new_suite() {
+static void sprintf_new_suite(void) {
     char *result;
 
     result = sprintf_new("Hello %d %s", 123, "World");
@@ -214,7 +214,7 @@ static void filter_o_opts_test(const char **init, const char **expected) {
     free(joined_input);
 }
 
-static void filter_o_opts_suite() {
+static void filter_o_opts_suite(void) {
     {
         const char *in[] = {"-obad1", NULL};
         const char *exp[] = {NULL};
@@ -299,7 +299,7 @@ static void filter_o_opts_suite() {
     }
 }
 
-static void test_internal_suite() {
+static void test_internal_suite(void) {
     arena_suite();
     my_dirname_suite();
     path_starts_with_suite();

--- a/tests/internals/test_rate_limiter.c
+++ b/tests/internals/test_rate_limiter.c
@@ -6,12 +6,12 @@ static const double epsilon = 0.000000000001;
 
 static volatile double time_now = 123123.0;
 
-double test_clock()
+double test_clock(void)
 {
     return time_now;
 }
 
-void computes_correct_sleep_times()
+void computes_correct_sleep_times(void)
 {
     time_now = 123123.0;
     RateLimiter limiter;
@@ -29,7 +29,7 @@ void computes_correct_sleep_times()
     rate_limiter_destroy(&limiter);
 }
 
-void works_after_being_idle()
+void works_after_being_idle(void)
 {
     time_now = 123123.0;
     RateLimiter limiter;
@@ -45,7 +45,7 @@ void works_after_being_idle()
     rate_limiter_destroy(&limiter);
 }
 
-void sleeps_correct_amount()
+void sleeps_correct_amount(void)
 {
     RateLimiter limiter;
     rate_limiter_init(&limiter, 10, &gettimeofday_clock);
@@ -58,7 +58,7 @@ void sleeps_correct_amount()
     rate_limiter_destroy(&limiter);
 }
 
-void rate_limiter_suite()
+void rate_limiter_suite(void)
 {
     computes_correct_sleep_times();
     works_after_being_idle();

--- a/tests/odirect_read.c
+++ b/tests/odirect_read.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
 
 #include <stdio.h>
 
-int main() {
+int main(void) {
     fprintf(stderr, "Not supported on this platform.\n");
     return 1;
 }

--- a/tests/odirect_write.c
+++ b/tests/odirect_write.c
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
 
 #include <stdio.h>
 
-int main() {
+int main(void) {
     fprintf(stderr, "Not supported on this platform.\n");
     return 1;
 }

--- a/tests/odirect_write.c
+++ b/tests/odirect_write.c
@@ -32,7 +32,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    size_t total_size = 0;
     while (1) {
         if (feof(stdin)) {
             break;
@@ -47,8 +46,6 @@ int main(int argc, char** argv) {
         if (amt_read == 0) {
             continue;
         }
-
-        total_size += amt_read;
 
         ssize_t res = write(fd, buf, buf_size);
         if (res == -1) {

--- a/tests/test_dir_rewind.c
+++ b/tests/test_dir_rewind.c
@@ -17,7 +17,7 @@
 
 #define BUF_SIZE 4096
 
-int main()
+int main(void)
 {
     int fd = open(".", O_RDONLY | O_DIRECTORY);
     if (fd == -1) {
@@ -72,7 +72,7 @@ int main()
 
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     printf("This test currently only compiles on Linux/amd64.\n");
     printf("Skipping by just returning successfully.\n");


### PR DESCRIPTION
Hi @mpartel,

after we last spoke I realized that we are not covering macOS yet but that it should economically be possible.  While working on macOS CI I noticed that the compile matrix was previously not applied in reality but using the single same default compiler everywhere (:facepalm: sorry!) and when I made CI use the right compiler respecting the matrix, new warnings showed up that needed fixing, so I fixed those as well…

Import to note (or at least of interest) during review:
- Review on commit level advised again here rather than on whole diff level.
- macOS does not seem to have `nproc`.
- The *tests* are failing on macOS for now. Let's please agree to fix that outside this pull request to not extend scope further (and also because I have no access to macOS outside of CI).
- Commit `odirect_write.c: Resolve unused variable "total_size"` needs close review, maybe there's an actual bug to be fixed there, instead?

Looking forward to your feedback!

Best, Sebastian