### PR TITLE
readdir: Fix empty content for directories containing broken symlinks

### DIFF
--- a/src/bindfs.c
+++ b/src/bindfs.c
@@ -893,7 +893,7 @@ static int bindfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
                         break;
                     }
                     free(resolved);
-                } else {
+                } else if (lstat(path_buf.ptr, &st) == -1) {
                     result = -errno;
                     break;
                 }


### PR DESCRIPTION
When using resolve-symlinks option, directories containing broken symlinks in the output mount point are displayed with empty content.

***For example, empty content*** :
```
$ mkdir -p a/b
$ touch a/b/c

# create a broken link:
$ ln -s ../d a/b

$ file a/b/*
a/b/c: empty
a/b/d: broken symbolic link to ../d

$ mkdir out
$ bindfs --resolve-symlinks a out

# empty output:
$ ls out/b
# remove d and try again:
$ rm a/b/d
$ ls out/b
c

$ fusermount -u out
```

*Cause*:
* In `bindfs_readdir()`, if a symlink is not resolved, the function stops processing the readdir immediately.

*Solution*:
* In the mentioned condition, continue to read stat for broken symlink and continue the readdir processing.

***After the change, directory entries are correctly displayed***:
```
$ mkdir -p a/b
$ touch a/b/c

# create a broken link:
$ ln -s ../d a/b

$ file a/b/*
a/b/c: empty
a/b/d: broken symbolic link to ../d

$ bindfs --resolve-symlinks a out

$ file out/b/*
out/b/c: empty
out/b/d: broken symbolic link to ../d

$ ls -aln */b/d
lrwxrwxrwx. 1 41136 10513 4 Oct  3 20:24 a/b/d -> ../d
lrwxrwxrwx. 1 41136 10513 4 Oct  3 20:24 out/b/d -> ../d

$ fusermount -u out
```
