### PR TITLE
Enable `subdir-objects` automake option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([bindfs],[1.18.4],[martin.partel@gmail.com])
 
-AM_INIT_AUTOMAKE([foreign serial-tests])
+AM_INIT_AUTOMAKE([foreign serial-tests subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CC


### PR DESCRIPTION
Before this change, autogen.sh produced warnings:

```
tests/internals/Makefile.am:4: warning: source file '$(top_srcdir)/src/misc.c' is in a subdirectory,
tests/internals/Makefile.am:4: but option 'subdir-objects' is disabled
```